### PR TITLE
Consume stdin to prevent SIGPIPE for producer

### DIFF
--- a/include/log.sh
+++ b/include/log.sh
@@ -87,6 +87,7 @@ _log_write() {
 	local line
 
 	if (( __log_verbosity < level )); then
+		[[ $# == 2 ]] &&  IFS="" read -r -d ""
 		return 0
 	fi
 


### PR DESCRIPTION
When the level of the log output is greater that the verbosity level when reading from stdin, simply returning 0 causes output-producing processes to receive a SIGPIPE signal.

To avoid this case, a line was added to consume everything read from stdin without echoing (basically the same as `cat >/dev/null` but with shell internals only).